### PR TITLE
Collision callback

### DIFF
--- a/src/physics/arcade/ArcadePhysics.ts
+++ b/src/physics/arcade/ArcadePhysics.ts
@@ -159,7 +159,7 @@ export class ArcadePhysics {
    *
    * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object1 - The first object or array of objects to check.
    * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} [object2] - The second object or array of objects to check, or `undefined`.
-   * @param {ArcadePhysicsCallback} [collideCallback] - An optional callback function that is called if the objects collide.
+   * @param {ArcadePhysicsCallback} [overlapCallback] - An optional callback function that is called if the objects collide.
    * @param {ArcadePhysicsCallback} [processCallback] - An optional callback function that lets you perform additional checks against the two objects if they overlap. If this is set then `collideCallback` will only be called if this callback returns `true`.
    * @param {*} [callbackContext] - The context in which to run the callbacks.
    *

--- a/src/physics/arcade/Collider.ts
+++ b/src/physics/arcade/Collider.ts
@@ -32,9 +32,9 @@ export class Collider {
     public overlapOnly: boolean,
     public body1: Body | StaticBody | Array<Body | StaticBody>,
     public body2: Body | StaticBody | Array<Body | StaticBody>,
-    public collideCallback: ArcadePhysicsCallback,
-    public processCallback: ArcadeProcessCallback,
-    public callbackContext
+    public collideCallback?: ArcadePhysicsCallback,
+    public processCallback?: ArcadeProcessCallback,
+    public callbackContext?: any
   ) {}
 
   /**

--- a/src/physics/arcade/Factory.ts
+++ b/src/physics/arcade/Factory.ts
@@ -6,7 +6,7 @@
 
 import { Body } from './Body'
 import { StaticBody } from './StaticBody'
-import { ArcadePhysicsCallback, ArcadeProcessCallback, CollisionCallback } from './typedefs/types'
+import { ArcadePhysicsCallback, ArcadeProcessCallback } from './typedefs/types'
 import type { World } from './World'
 
 export class Factory {
@@ -55,8 +55,8 @@ export class Factory {
   public collider(
     body1: Body | StaticBody | Array<Body | StaticBody>,
     body2: Body | StaticBody | Array<Body | StaticBody>,
-    collideCallback?: CollisionCallback,
-    processCallback?: CollisionCallback,
+    collideCallback?: ArcadePhysicsCallback,
+    processCallback?: ArcadeProcessCallback,
     callbackContext?: any
   ) {
     return this.world.addCollider(body1, body2, collideCallback, processCallback, callbackContext)

--- a/src/physics/arcade/StaticBody.ts
+++ b/src/physics/arcade/StaticBody.ts
@@ -10,7 +10,7 @@ import CONST from './const'
 import { Vector2 } from '../../math/Vector2'
 import { World } from './World'
 import type { Body } from './Body'
-import { ArcadeBodyBounds, CollisionCallback } from './typedefs/types'
+import { ArcadeBodyBounds, Collision } from './typedefs/types'
 
 export class StaticBody {
   debugShowBody: boolean
@@ -54,7 +54,7 @@ export class StaticBody {
   overlapR: number
   embedded: boolean
   collideWorldBounds: boolean
-  checkCollision: CollisionCallback
+  checkCollision: Collision
   touching: {
     none: boolean
     up: boolean

--- a/src/physics/arcade/World.ts
+++ b/src/physics/arcade/World.ts
@@ -31,7 +31,8 @@ import type {
   ArcadePhysicsCallback,
   ArcadeProcessCallback,
   ArcadeWorldDefaults,
-  ArcadeWorldTreeMinMax
+  ArcadeWorldTreeMinMax,
+  Collision
 } from './typedefs/types'
 
 interface ArcadeWorldConfig {
@@ -91,7 +92,7 @@ export class World extends EventEmitter {
   gravity: Vector2
   /** A boundary constraining Bodies. */
   bounds: Rectangle
-  checkCollision: { up: any; down: any; left: any; right: any }
+  checkCollision: Collision
   fps: number
   fixedStep: number
   _frameTime: number
@@ -677,20 +678,13 @@ export class World extends EventEmitter {
   public addCollider(
     body1: Body | StaticBody | Array<Body | StaticBody>,
     body2: Body | StaticBody | Array<Body | StaticBody>,
-    collideCallback,
-    processCallback,
-    callbackContext
+    collideCallback?: ArcadePhysicsCallback,
+    processCallback?: ArcadeProcessCallback,
+    callbackContext?: any
   ) {
-    if (collideCallback === undefined) {
-      collideCallback = null
-    }
-    if (processCallback === undefined) {
-      processCallback = null
-    }
     if (callbackContext === undefined) {
       callbackContext = collideCallback
     }
-
     const collider = new Collider(this, false, body1, body2, collideCallback, processCallback, callbackContext)
 
     this.colliders.add(collider)

--- a/src/physics/arcade/World.ts
+++ b/src/physics/arcade/World.ts
@@ -31,7 +31,8 @@ import type {
   ArcadePhysicsCallback,
   ArcadeProcessCallback,
   ArcadeWorldDefaults,
-  ArcadeWorldTreeMinMax
+  ArcadeWorldTreeMinMax,
+  Collision
 } from './typedefs/types'
 
 interface ArcadeWorldConfig {
@@ -91,7 +92,7 @@ export class World extends EventEmitter {
   gravity: Vector2
   /** A boundary constraining Bodies. */
   bounds: Rectangle
-  checkCollision: { up: any; down: any; left: any; right: any }
+  checkCollision: Collision
   fps: number
   fixedStep: number
   _frameTime: number

--- a/src/physics/arcade/typedefs/types.ts
+++ b/src/physics/arcade/typedefs/types.ts
@@ -12,9 +12,9 @@ export interface ArcadeBodyBounds {
   bottom: number
 }
 
-export interface CollisionCallback {
+export interface Collision {
   /** True if the Body is not colliding. */
-  none: boolean
+  none?: boolean
   /** True if the Body is colliding on its upper edge. */
   up: boolean
   /** True if the Body is colliding on its lower edge. */
@@ -24,6 +24,8 @@ export interface CollisionCallback {
   /** True if the Body is colliding on its right edge. */
   right: boolean
 }
+
+export type CollisionCallback = () => Collision
 
 export type ArcadeProcessCallback = () => boolean
 

--- a/src/physics/arcade/typedefs/types.ts
+++ b/src/physics/arcade/typedefs/types.ts
@@ -1,5 +1,6 @@
 import { BBox } from 'rbush'
 import { StaticBody } from '../StaticBody'
+import { Body } from '../Body'
 
 export interface ArcadeBodyBounds {
   /** The left edge. */
@@ -12,9 +13,9 @@ export interface ArcadeBodyBounds {
   bottom: number
 }
 
-export interface CollisionCallback {
+export interface Collision {
   /** True if the Body is not colliding. */
-  none: boolean
+  none?: boolean
   /** True if the Body is colliding on its upper edge. */
   up: boolean
   /** True if the Body is colliding on its lower edge. */
@@ -25,12 +26,14 @@ export interface CollisionCallback {
   right: boolean
 }
 
+export type CollisionCallback = () => Collision
+
 export type ArcadeProcessCallback = () => boolean
 
 export type ArcadePhysicsCallback = (
   body1: Body | StaticBody,
   body2: Body | StaticBody
-) => (body1: Body | StaticBody, body2: Body | StaticBody) => void
+ ) => void
 
 export interface ArcadeWorldConfig {
   overlapBias?: number


### PR DESCRIPTION
Replaced CollisionCallback with ArcadePhysicsCallback/ArcadeProcessCallback in Factory Class as mentioned in Phaser 3 documentation [https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Factory.html#collider__anchor](url).
Changed ArcadeProcessCallback type from
`(body1, body2) => (body1, body2) => void`
to
`(body1, body2) => void`
