### PR TITLE
Collider callbacks are now ArcadePhysicsCallback

### DIFF
--- a/src/physics/arcade/ArcadePhysics.ts
+++ b/src/physics/arcade/ArcadePhysics.ts
@@ -159,7 +159,7 @@ export class ArcadePhysics {
    *
    * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} object1 - The first object or array of objects to check.
    * @param {Phaser.Types.Physics.Arcade.ArcadeColliderType} [object2] - The second object or array of objects to check, or `undefined`.
-   * @param {ArcadePhysicsCallback} [collideCallback] - An optional callback function that is called if the objects collide.
+   * @param {ArcadePhysicsCallback} [overlapCallback] - An optional callback function that is called if the objects collide.
    * @param {ArcadePhysicsCallback} [processCallback] - An optional callback function that lets you perform additional checks against the two objects if they overlap. If this is set then `collideCallback` will only be called if this callback returns `true`.
    * @param {*} [callbackContext] - The context in which to run the callbacks.
    *

--- a/src/physics/arcade/Collider.ts
+++ b/src/physics/arcade/Collider.ts
@@ -32,9 +32,9 @@ export class Collider {
     public overlapOnly: boolean,
     public body1: Body | StaticBody | Array<Body | StaticBody>,
     public body2: Body | StaticBody | Array<Body | StaticBody>,
-    public collideCallback: ArcadePhysicsCallback,
-    public processCallback: ArcadeProcessCallback,
-    public callbackContext
+    public collideCallback?: ArcadePhysicsCallback,
+    public processCallback?: ArcadeProcessCallback,
+    public callbackContext?: any
   ) {}
 
   /**

--- a/src/physics/arcade/Factory.ts
+++ b/src/physics/arcade/Factory.ts
@@ -6,7 +6,7 @@
 
 import { Body } from './Body'
 import { StaticBody } from './StaticBody'
-import { ArcadePhysicsCallback, ArcadeProcessCallback, CollisionCallback } from './typedefs/types'
+import { ArcadePhysicsCallback, ArcadeProcessCallback } from './typedefs/types'
 import type { World } from './World'
 
 export class Factory {
@@ -55,8 +55,8 @@ export class Factory {
   public collider(
     body1: Body | StaticBody | Array<Body | StaticBody>,
     body2: Body | StaticBody | Array<Body | StaticBody>,
-    collideCallback?: CollisionCallback,
-    processCallback?: CollisionCallback,
+    collideCallback?: ArcadePhysicsCallback,
+    processCallback?: ArcadeProcessCallback,
     callbackContext?: any
   ) {
     return this.world.addCollider(body1, body2, collideCallback, processCallback, callbackContext)

--- a/src/physics/arcade/World.ts
+++ b/src/physics/arcade/World.ts
@@ -678,16 +678,10 @@ export class World extends EventEmitter {
   public addCollider(
     body1: Body | StaticBody | Array<Body | StaticBody>,
     body2: Body | StaticBody | Array<Body | StaticBody>,
-    collideCallback,
-    processCallback,
-    callbackContext
+    collideCallback?: ArcadePhysicsCallback,
+    processCallback?: ArcadeProcessCallback,
+    callbackContext?: any
   ) {
-    if (collideCallback === undefined) {
-      collideCallback = null
-    }
-    if (processCallback === undefined) {
-      processCallback = null
-    }
     if (callbackContext === undefined) {
       callbackContext = collideCallback
     }

--- a/src/physics/arcade/typedefs/types.ts
+++ b/src/physics/arcade/typedefs/types.ts
@@ -1,5 +1,6 @@
 import { BBox } from 'rbush'
 import { StaticBody } from '../StaticBody'
+import { Body } from '../Body'
 
 export interface ArcadeBodyBounds {
   /** The left edge. */
@@ -32,7 +33,7 @@ export type ArcadeProcessCallback = () => boolean
 export type ArcadePhysicsCallback = (
   body1: Body | StaticBody,
   body2: Body | StaticBody
-) => (body1: Body | StaticBody, body2: Body | StaticBody) => void
+) => void
 
 export interface ArcadeWorldConfig {
   overlapBias?: number


### PR DESCRIPTION
Collider callback are now ArcadePhysicsCallbacks and collider process callbacks are now ArcadeProcessCallbacks as mentioned in Phaser 3 documentation.  (documentation below)
[https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Collider.html#Collider__anchor](url)
[https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.World.html#addCollider__anchor](url)
[https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Factory.html#collider__anchor](url)
Simplified type of ArcadePhysicsCallback from
`(body1, body2) => (body1, body2) => void` to `(body1, body2) => void` (documentation below)
[https://photonstorm.github.io/phaser3-docs/global.html#ArcadePhysicsCallback](url)